### PR TITLE
Change CSSOM dependency to point directly to GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "q" : "0.9.6",
         "native": "~0.2.0",
         "collections": "~0.2.1",
-        "cssom" : "0.3.0",
+        "cssom" : "git+https://github.com/NV/CSSOM.git#gh-pages",
         "url" : "0.7.9"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "q" : "0.9.6",
         "native": "~0.2.0",
         "collections": "~0.2.1",
-        "cssom" : "git+https://github.com/NV/CSSOM.git#gh-pages",
+        "cssom" : "git+https://github.com/montagejs/CSSOM.git#gh-pages",
         "url" : "0.7.9"
     },
     "repository": {


### PR DESCRIPTION
This fixes an issue where mop would remove a parameter in the CSSOM
files, causing a syntax error in Chrome
