### PR TITLE
Fix error in iOS 9

### DIFF
--- a/runtime/glsl-program.js
+++ b/runtime/glsl-program.js
@@ -288,7 +288,7 @@ var GLSLProgram = exports.GLSLProgram = Object.create(Object.prototype, {
         value: function(symbol,value)  {
             var existingValue = this.symbolToValue[symbol];
             var type = this.getTypeForSymbol(symbol);
-            var GL = WebGLRenderingContext;
+            var GL = WebGLRenderingContext.prototype;
 
             if (( value != null) && (existingValue != null)) {
                 if (type === GL.FLOAT) {
@@ -377,35 +377,37 @@ var GLSLProgram = exports.GLSLProgram = Object.create(Object.prototype, {
 
     _commitSwitch: {
         value: (function () {
+            var GL = WebGLRenderingContext.prototype;
+
             var theSwitch = [];
-            theSwitch[WebGLRenderingContext.FLOAT_MAT2] = function uniformMatrix2fv(GL, location , count, value) {
+            theSwitch[GL.FLOAT_MAT2] = function uniformMatrix2fv(GL, location , count, value) {
                 GL.uniformMatrix2fv(location , count, value);
             };
-            theSwitch[WebGLRenderingContext.FLOAT_MAT3] = function uniformMatrix3fv(GL, location , count, value) {
+            theSwitch[GL.FLOAT_MAT3] = function uniformMatrix3fv(GL, location , count, value) {
                 GL.uniformMatrix3fv(location , count, value);
             };
-            theSwitch[WebGLRenderingContext.FLOAT_MAT4] = function uniformMatrix4fv(GL, location , count, value) {
+            theSwitch[GL.FLOAT_MAT4] = function uniformMatrix4fv(GL, location , count, value) {
                 GL.uniformMatrix4fv(location , count, value);
             };
-            theSwitch[WebGLRenderingContext.FLOAT] = function uniform1f(GL, location , count, value) {
+            theSwitch[GL.FLOAT] = function uniform1f(GL, location , count, value) {
                 GL.uniform1f(location,value);
             };
-            theSwitch[WebGLRenderingContext.FLOAT_VEC2] = function uniform2fv(GL, location , count, value) {
+            theSwitch[GL.FLOAT_VEC2] = function uniform2fv(GL, location , count, value) {
                 GL.uniform2fv(location,value);
             };
-            theSwitch[WebGLRenderingContext.FLOAT_VEC3] = function uniform3fv(GL, location , count, value) {
+            theSwitch[GL.FLOAT_VEC3] = function uniform3fv(GL, location , count, value) {
                 GL.uniform3fv(location,value);
             };
-            theSwitch[WebGLRenderingContext.FLOAT_VEC4] = function uniform4fv(GL, location , count, value) {
+            theSwitch[GL.FLOAT_VEC4] = function uniform4fv(GL, location , count, value) {
                 GL.uniform4fv(location,value);
             };
-            theSwitch[WebGLRenderingContext.INT] = function uniform1i(GL, location , count, value) {
+            theSwitch[GL.INT] = function uniform1i(GL, location , count, value) {
                 GL.uniform1i(location, value);
             };
-            theSwitch[WebGLRenderingContext.SAMPLER_2D] = function uniform1i(GL, location , count, value) {
+            theSwitch[GL.SAMPLER_2D] = function uniform1i(GL, location , count, value) {
                 GL.uniform1i(location, value);
             };
-            theSwitch[WebGLRenderingContext.SAMPLER_CUBE] = function uniform1i(GL, location , count, value) {
+            theSwitch[GL.SAMPLER_CUBE] = function uniform1i(GL, location , count, value) {
                 GL.uniform1i(location, value);
             };
 

--- a/runtime/helpers/resource-manager.js
+++ b/runtime/helpers/resource-manager.js
@@ -721,22 +721,24 @@ exports.WebGLTFResourceManager = Object.create(Object, {
 
     _elementSizeForGLType: {
         value: function(glType) {
+            var GL = WebGLRenderingContext.prototype;
+
             switch (glType) {
-                case WebGLRenderingContext.FLOAT :
+                case GL.FLOAT :
                     return Float32Array.BYTES_PER_ELEMENT;
-                case WebGLRenderingContext.UNSIGNED_BYTE:
+                case GL.UNSIGNED_BYTE:
                     return Uint8Array.BYTES_PER_ELEMENT;
-                case WebGLRenderingContext.UNSIGNED_SHORT:
+                case GL.UNSIGNED_SHORT:
                     return Uint16Array.BYTES_PER_ELEMENT;
-                case WebGLRenderingContext.FLOAT_VEC2:
+                case GL.FLOAT_VEC2:
                     return Float32Array.BYTES_PER_ELEMENT * 2;
-                case WebGLRenderingContext.FLOAT_VEC3:
+                case GL.FLOAT_VEC3:
                     return Float32Array.BYTES_PER_ELEMENT * 3;
-                case WebGLRenderingContext.FLOAT_VEC4:
+                case GL.FLOAT_VEC4:
                     return Float32Array.BYTES_PER_ELEMENT * 4;
-                case WebGLRenderingContext.FLOAT_MAT4:
+                case GL.FLOAT_MAT4:
                     return Float32Array.BYTES_PER_ELEMENT * 16;
-                case WebGLRenderingContext.FLOAT_MAT3:
+                case GL.FLOAT_MAT3:
                     return Float32Array.BYTES_PER_ELEMENT * 9;
                 default:
                     return null;

--- a/runtime/material.js
+++ b/runtime/material.js
@@ -111,13 +111,14 @@ exports.Material = Component3D.specialize( {
 
     parameterForImagePath: {
         value: function(imagePath) {
+            var GL = WebGLRenderingContext.prototype;
 
             var sampler = {
-                "magFilter": WebGLRenderingContext.LINEAR,
-                "minFilter": WebGLRenderingContext.LINEAR,
+                "magFilter": GL.LINEAR,
+                "minFilter": GL.LINEAR,
                 "type": "sampler",
-                "wrapS" : WebGLRenderingContext.REPEAT,
-                "wrapT" : WebGLRenderingContext.REPEAT
+                "wrapS" : GL.REPEAT,
+                "wrapT" : GL.REPEAT
             };
 
             var source = {
@@ -132,12 +133,12 @@ exports.Material = Component3D.specialize( {
             var parameterValue = {
                 "baseId": "texture-" + imagePath,
                 "id": "texture-" + imagePath,
-                "format": WebGLRenderingContext.RGBA,
-                "internalFormat" : WebGLRenderingContext.RGBA,
+                "format": GL.RGBA,
+                "internalFormat" : GL.RGBA,
                 "sampler" : sampler,
                 "source" : source,
                 "type" : "texture",
-                "target" : WebGLRenderingContext.TEXTURE_2D
+                "target" : GL.TEXTURE_2D
             };
 
             var parameter = {

--- a/runtime/runtime-tf-loader.js
+++ b/runtime/runtime-tf-loader.js
@@ -168,8 +168,8 @@ exports.RuntimeTFLoader = Object.create(glTFParser, {
                         parameter.value = values[parameterSid];
                         var paramValue = null;
                         switch (parameter.type) {
-                            case WebGLRenderingContext.SAMPLER_CUBE:
-                            case WebGLRenderingContext.SAMPLER_2D:
+                            case WebGLRenderingContext.prototype.SAMPLER_CUBE:
+                            case WebGLRenderingContext.prototype.SAMPLER_2D:
                             {
                                 var entry = this.getEntry(parameter.value);
                                 if (entry) {
@@ -253,7 +253,7 @@ exports.RuntimeTFLoader = Object.create(glTFParser, {
             for (var i = 0 ; i < primitivesDescription.length ; i++) {
                 var primitiveDescription = primitivesDescription[i];
 
-                if (primitiveDescription.primitive === WebGLRenderingContext.TRIANGLES) {
+                if (primitiveDescription.primitive === WebGLRenderingContext.prototype.TRIANGLES) {
                     var primitive = Object.create(Primitive).init();
 
                     //read material
@@ -544,6 +544,8 @@ exports.RuntimeTFLoader = Object.create(glTFParser, {
                 this._animations = [];
             }
 
+            var GL = WebGLRenderingContext.prototype;
+
             var animation = Object.create(KeyframeAnimation).initWithDescription(description);
             animation.id =  entryID;
             this.storeEntry(entryID, animation, description);
@@ -555,16 +557,16 @@ exports.RuntimeTFLoader = Object.create(glTFParser, {
                 parameterDescription = this.getEntry(parameterUID).entry;
                 //we can avoid code below if we add byteStride
                 switch (parameterDescription.type) {
-                    case WebGLRenderingContext.FLOAT_VEC4:
+                    case GL.FLOAT_VEC4:
                         componentsPerAttribute = 4;
                         break;
-                    case WebGLRenderingContext.FLOAT_VEC3:
+                    case GL.FLOAT_VEC3:
                         componentsPerAttribute = 3;
                         break;
-                    case WebGLRenderingContext.FLOAT_VEC2:
+                    case GL.FLOAT_VEC2:
                         componentsPerAttribute = 2;
                         break;
-                    case WebGLRenderingContext.FLOAT:
+                    case GL.FLOAT:
                         componentsPerAttribute = 1;
                         break;
                     default: {

--- a/runtime/webgl-renderer.js
+++ b/runtime/webgl-renderer.js
@@ -418,11 +418,11 @@ exports.WebGLRenderer = Object.create(Object.prototype, {
     textureDelegate: {
         value: {
             getGLFilter: function(filter) {
-                return filter == null ? WebGLRenderingContext.LINEAR : filter;
+                return filter == null ? WebGLRenderingContext.prototype.LINEAR : filter;
             },
 
             getGLWrapMode: function(wrapMode) {
-                return wrapMode == null ? WebGLRenderingContext.REPEAT : wrapMode;
+                return wrapMode == null ? WebGLRenderingContext.prototype.REPEAT : wrapMode;
             },
 
             handleError: function(errorCode, info) {

--- a/ui/scene-view.reel/scene-view.js
+++ b/ui/scene-view.reel/scene-view.js
@@ -249,7 +249,15 @@ exports.SceneView = Component.specialize( {
 
     translateComposer: { value: null, writable: true },
 
-    scaleFactor: { value: (window.devicePixelRatio || 1), writable: true},
+    scaleFactor: {
+        get: function() {
+            if (this._isiPad()) {
+                return 1;
+            }
+
+            return window.devicePixelRatio || 1;
+        }
+    },
 
     selectedNode: { value: null, writable:true },
 
@@ -638,6 +646,12 @@ exports.SceneView = Component.specialize( {
     getRelativePositionToCanvas: {
         value: function(event) {
             return dom.convertPointFromPageToNode(this.canvas, Point.create().init(event.pageX, event.pageY));
+        }
+    },
+    
+    _isiPad: {
+        value: function() {
+            return !!navigator.userAgent.match(/iPad/i);
         }
     },
 


### PR DESCRIPTION
Rendering constants have moved from WebGLRenderingContext to WebGLRenderingContext.prototype. Does not break non-iOS 9 versions.
